### PR TITLE
Changes to be compatible with prompt-toolkit=0.52

### DIFF
--- a/saws/keys.py
+++ b/saws/keys.py
@@ -74,7 +74,10 @@ class KeyManager(object):
         assert callable(get_shortcut_match)
         assert callable(refresh_resources)
         assert callable(handle_docs)
-        self.manager = KeyBindingManager(enable_system_bindings=True)
+        self.manager = KeyBindingManager(
+           enable_search=True,
+           enable_abort_and_exit_bindings=True,
+           enable_system_bindings=True)
 
         @self.manager.registry.add_binding(Keys.F2)
         def handle_f2(_):

--- a/saws/saws.py
+++ b/saws/saws.py
@@ -23,6 +23,7 @@ import webbrowser
 from prompt_toolkit import AbortAction, Application, CommandLineInterface
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Always, HasFocus, IsDone
+from prompt_toolkit.interface import AcceptAction
 from prompt_toolkit.layout.processors import \
     HighlightMatchingBracketProcessor, ConditionalProcessor
 from prompt_toolkit.buffer import Buffer
@@ -382,7 +383,8 @@ class Saws(object):
         cli_buffer = Buffer(
             history=history,
             completer=self.completer,
-            complete_while_typing=Always())
+            complete_while_typing=Always(),
+            accept_action=AcceptAction.RETURN_DOCUMENT)
         self.key_manager = KeyManager(
             self.set_color,
             self.get_color,
@@ -394,11 +396,13 @@ class Saws(object):
             self.handle_docs)
         style_factory = StyleFactory(self.theme)
         application = Application(
+            mouse_support=True,
             style=style_factory.style,
             layout=layout,
             buffer=cli_buffer,
             key_bindings_registry=self.key_manager.manager.registry,
             on_exit=AbortAction.RAISE_EXCEPTION,
+            on_abort=AbortAction.RETRY,
             ignore_case=True)
         eventloop = create_eventloop()
         self.aws_cli = CommandLineInterface(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'enum34>=1.0.4',
         'fuzzyfinder>=1.0.0',
         'ordereddict>=1.1',
-        'prompt-toolkit>=0.46,<=0.50',
+        'prompt-toolkit==0.52',
         'six>=1.9.0',
         'pygments>=2.0.2'
     ],


### PR DESCRIPTION
There are a few backward incompatible changes in prompt-toolkit 0.52. I don't recommend supporting both the latest and previous versions. This pull request makes the required changes to keep everything working like it was.

One additional change is that mouse support is on. Feel free to change the pull request to disable mouse support.