### PR TITLE
Add Dockerfile for running SAWS in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+
+RUN apt-get update && \
+  apt-get install -y python-pip && \
+  pip install saws
+
+ENTRYPOINT ["saws"]


### PR DESCRIPTION
Assuming Docker is installed, the container can be built by running `docker build -t saws .` and run via 
```
docker run -it -e AWS_ACCESS_KEY_ID=<key> -e AWS_SECRET_ACCESS_KEY=<secret> -e AWS_DEFAULT_REGION=<region> saws
```

The container is currently pretty large as it's based on `ubuntu:latest`. Ultimately, it would be nice if this can be based on `alpine:latest` similar to https://github.com/anigeo/docker-awscli but I'm not yet sure how to get tty to work.

Similar to `docker-awscli`, keys can be passed in via env vars as shown above or by attaching the host's `.aws` to the container `docker run -it -v ~/.aws/:/root/.aws:ro saws`

If there's interest I can attempt to shrink the image, add to the README and publish to Dockerhub.