### PR TITLE
Fix installation of groff and follow Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:latest
 
-RUN apt-get update groff && \
-  apt-get install -y python-pip && \
-  pip install saws
+RUN apt-get update && apt-get install -y \
+    groff \
+    python-pip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install saws
 
 ENTRYPOINT ["saws"]


### PR DESCRIPTION
The current Dockerfile does not install groff and doesn't follow [Dockerfile best practice](http://docs.docker.com/engine/articles/dockerfile_best-practices/).

This builds a fully working container. I've set up an automated build at <https://hub.docker.com/r/stilvoid/saws/>.