### PR TITLE
Use alpine and build docker image from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*
+*.egg*
+dist/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:latest
+FROM python:alpine
 
-RUN apt-get update && apt-get install -y \
-    groff \
-    python-pip \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+ADD . /saws/
 
-RUN pip install saws
+RUN cd saws && python setup.py install && cd ..
 
 ENTRYPOINT ["saws"]


### PR DESCRIPTION
Connects to #51 

* Modify Dockerfile to leverage smaller alpine based instance
* Build image from sources rather than downloading from pip

Automated builds on https://hub.docker.com/r/frosforever/saws/ building off `docker` branch can be run via: 
```
docker run -it -v ~/.aws/:/root/.aws:ro frosforever/saws:docker
```