### PR TITLE
Update Sphinx docs dependencies and CHECKLIST

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -61,7 +61,7 @@ P. Upload to PyPi
 
     $ python setup.py sdist upload -r pypi
 
-Q. Upload Sphinx docs to PyPi
+Q. Upload Sphinx docs to PyPi (requires Python2)
 
     $ python setup.py upload_sphinx
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ mock>=1.0.1
 pexpect>=3.3
 pytest>=2.7.0
 tox>=1.9.2
-sphinx>=1.3.1
-Sphinx-PyPI-upload>=0.2.1
+sphinx==1.3.1
+Sphinx-PyPI-upload==0.2.1
 gitchangelog>=2.2.1


### PR DESCRIPTION
More recent versions of `sphinx` seem to have introduce changes that need to be sorted out for SAWS to support them.

CHECKLIST: `Sphinx-PyPI-upload` seems to only be supported for Python2.