### PR TITLE
Fix #91: Update feed_key to feed and process_keys

### DIFF
--- a/saws/saws.py
+++ b/saws/saws.py
@@ -366,7 +366,8 @@ class Saws(object):
         else:
             # Clear the renderer and send a carriage return
             self.aws_cli.renderer.clear()
-            self.aws_cli.input_processor.feed_key(KeyPress(Keys.ControlM, ''))
+            self.aws_cli.input_processor.feed(KeyPress(Keys.ControlM, u''))
+            self.aws_cli.input_processor.process_keys()
 
     def _process_command(self, text):
         """Processes the input command, called by the cli event loop

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -31,31 +31,35 @@ class KeysTest(unittest.TestCase):
         self.DOCS_HOME_URL = \
             'http://docs.aws.amazon.com/cli/latest/reference/index.html'
 
+    def feed_key(self, key):
+        self.processor.feed(KeyPress(key, u''))
+        self.processor.process_keys()
+
     def test_F2(self):
         orig_color = self.saws.get_color()
-        self.processor.feed_key(KeyPress(Keys.F2, ''))
+        self.feed_key(Keys.F2)
         assert orig_color != self.saws.get_color()
 
     def test_F3(self):
         orig_fuzzy = self.saws.get_fuzzy_match()
-        self.processor.feed_key(KeyPress(Keys.F3, ''))
+        self.feed_key(Keys.F3)
         assert orig_fuzzy != self.saws.get_fuzzy_match()
 
     def test_F4(self):
         orig_shortcut = self.saws.get_shortcut_match()
-        self.processor.feed_key(KeyPress(Keys.F4, ''))
+        self.feed_key(Keys.F4)
         assert orig_shortcut != self.saws.get_shortcut_match()
 
     @mock.patch('saws.saws.webbrowser')
     def test_F9(self, mock_webbrowser):
-        self.processor.feed_key(KeyPress(Keys.F9, ''))
+        self.feed_key(Keys.F9)
         mock_webbrowser.open.assert_called_with(self.DOCS_HOME_URL)
 
     def test_F10(self):
         with self.assertRaises(EOFError):
-            self.processor.feed_key(KeyPress(Keys.F10, ''))
+            self.feed_key(Keys.F10)
 
     @mock.patch('saws.resources.print')
     def test_f5(self, mock_print):
-        self.processor.feed_key(KeyPress(Keys.F5, ''))
+        self.feed_key(Keys.F5)
         mock_print.assert_called_with('Done refreshing')

--- a/tests/test_saws.py
+++ b/tests/test_saws.py
@@ -143,7 +143,7 @@ class SawsTest(unittest.TestCase):
 
     def test_handle_keyboard_interrupt(self):
         e = KeyboardInterrupt('')
-        # TODO: Mock calls to renderer.clear and input_processor.feed_key
+        # TODO: Mock calls to renderer.clear and input_processor.feed
         self.saws._handle_keyboard_interrupt(e, platform='Darwin')
         with self.assertRaises(KeyboardInterrupt):
             self.saws._handle_keyboard_interrupt(e, platform='Windows')


### PR DESCRIPTION
feed_key was separated to feed and process_keys in prompt-toolkit 1.0.1.